### PR TITLE
Avoid time after

### DIFF
--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -1,2 +1,2 @@
 tenets:
-  - import: codelingo/go/ticker-in-for-switch
+  - import: codelingo/go/ticker-in-for-select

--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -1,0 +1,2 @@
+tenets:
+  - import: codelingo/go/ticker-in-for-switch


### PR DESCRIPTION
Rather than creating a new timer for each iteration, one timer should be defined and reset after each iteration. When using time.After() it's valuable to know that ["The underlying Timer is not recovered by the garbage collector until the timer fires. If efficiency is a concern, use NewTimer instead and call Timer.Stop if the timer is no longer needed."](https://golang.org/src/time/sleep.go?s=4766:4800#L143)

This issue was found using the CodeLingo Tenet [ticker-in-for-select](https://github.com/codelingo/codelingo/blob/master/tenets/codelingo/go/ticker-in-for-select/codelingo.yaml) which I have added to your codelingo.yaml.